### PR TITLE
Use dynamic github token

### DIFF
--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "${GITHUB_USER}"
           git config --global user.email "${GITHUB_USER}@appscode.com"
@@ -35,7 +35,7 @@ jobs:
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/update-crds.yml
+++ b/.github/workflows/update-crds.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Clone installer repository
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INSTALLER_REPOSITORY: ${{ secrets.INSTALLER_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${INSTALLER_REPOSITORY}.git"
@@ -50,8 +50,8 @@ jobs:
 
       - name: Update crds
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INSTALLER_REPOSITORY: ${{ secrets.INSTALLER_REPOSITORY }}
         run: |
           export INSTALLER_ROOT=$RUNNER_WORKSPACE/$(basename $INSTALLER_REPOSITORY)


### PR DESCRIPTION
Replace hardcoded `1gtm` user and `LGTM_GITHUB_TOKEN` with the workflow-provided `github.actor` and default `GITHUB_TOKEN` in CI workflows. Mirrors https://github.com/kubedb/apimachinery/pull/1668.